### PR TITLE
Add additional condition to recognize 3ware binary

### DIFF
--- a/debian/patches/check_raid/binary
+++ b/debian/patches/check_raid/binary
@@ -1,0 +1,13 @@
+Index: check_raid/check_raid
+===================================================================
+--- check_raid.orig/check_raid	2013-01-28 12:47:07.807913303 +0100
++++ check_raid/check_raid	2013-01-28 12:48:02.748424922 +0100
+@@ -83,7 +83,7 @@
+ my $metastat = which('metastat');
+ my $lsvg = which('lsvg');
+ my $ipssend = which('ipssend');
+-my $tw_cli = which('tw_cli-9xxx') || which('tw_cli')
++my $tw_cli = which('tw_cli-9xxx') || which('tw_cli') || which('tw-cli');
+ my $arcconf = which('arcconf');
+ my $megarc = which('megarc');
+ my $cmdtool2 = which('CmdTool2');

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -21,3 +21,4 @@ check_rbl/spelling_errors
 check_haproxy/epn
 check_httpd_status/epn
 check_backuppc/use_nagios_plugins
+check_raid/binary


### PR DESCRIPTION
This is a patch for check_raid to recognize the binary, because the hoster of http://hwraid.le-vert.net/debian/ renamed the binary from tw_cli to tw-cli.
