### PR TITLE
check_packages should find security updates on the official security mirror too

### DIFF
--- a/debian/patches/dsa/security_updates_critical
+++ b/debian/patches/dsa/security_updates_critical
@@ -22,7 +22,7 @@
 +			} else {
 +				$candidate_found = 0;
 +			}
-+		} elsif (($line =~ / +[0-9]+ [^ ]+\/debian-security.*\/updates\//) && $candidate_found ) {
++		} elsif (($line =~ / +[0-9]+ [^ ]+\/(security\.([^ ]+\.)?debian\.org|debian-security).*\/updates\//) && $candidate_found ) {
 +			$installed->{$pkgname}{'security-update'} = 1;
  		} elsif ($line =~ /^ +\*\*\*/) {
  			my @l;


### PR DESCRIPTION
[1] says one should use the following line to get security updates for Debian:
  deb http://security.debian.org/ wheezy/updates main contrib non-free
this produces the following `apt-cache policy <pkg>` output:
  500 http://security.debian.org/ wheezy/updates/main amd64 Packages
which does not match the current regex, as this looks for `debian-security`
(which is only present on "regular" Debian mirrors).

The new regex matches security.debian.org and also the (obsolete)
security.eu.debian.org and security.us.debian.org names.

[1] http://www.debian.org/security/

(yay, 13 lines commit message for a 1 line patch)
