### PR TITLE
check_libs: ignore /var/lib/postgresql/ and /var/log/

### DIFF
--- a/check_libs/nagios-check-libs.conf
+++ b/check_libs/nagios-check-libs.conf
@@ -12,4 +12,5 @@
     - '$path =~ m#^/dev/zero#'
     - '$path =~ m#^/dev/shm/#'
     - '$path =~ m#^/var/lib/postgresql/#'
+    - '$path =~ m#^/var/log/#'
 # vim:syn=yaml


### PR DESCRIPTION
it contains only data and produces false-positives like this:
adding postgres(5733) because of [/var/lib/postgresql/9.2/main/pg_xlog/000000010000002D000000F9 (deleted)]:
