### PR TITLE
check_libs: ignore /var/lib/ganeti/

### DIFF
--- a/check_libs/nagios-check-libs.conf
+++ b/check_libs/nagios-check-libs.conf
@@ -14,4 +14,5 @@
     - '$path =~ m#^/var/lib/postgresql/#'
     - '$path =~ m#^/var/log/#'
     - '$path =~ m#^/var/spool/#'
+    - '$path =~ m#^/var/lib/ganeti/#' 
 # vim:syn=yaml


### PR DESCRIPTION
ganeti stores a lot of state files here, and sometimes also deletes them
