### PR TITLE
do not build check_varnish and check_memcached on hurd-i386

### DIFF
--- a/check_memcached/control
+++ b/check_memcached/control
@@ -1,4 +1,4 @@
-Build-Depends: flex, libmemcached-dev
+Build-Depends: flex, libmemcached-dev [!hurd-i386 !arm64]
 Homepage: http://exchange.nagios.org/directory/Plugins/Websites,-Forms-and-Transactions/check_memcached-IV/details
 Version: 1.3
 Uploaders: Bernd Zeimetz <bzed@debian.org>

--- a/check_varnish/control
+++ b/check_varnish/control
@@ -1,5 +1,5 @@
 Uploaders: Bernd Zeimetz <bzed@debian.org>
-Build-Depends: libvarnishapi-dev, pkg-config
+Build-Depends: libvarnishapi-dev [!hurd-i386 !m68k], pkg-config
 Version: 1.1
 Homepage: http://repo.varnish-cache.org/source/
 Watch: http://repo.varnish-cache.org/source/ varnish-nagios-([0-9.]+)\.tar\.gz

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: net
 Priority: extra
 Maintainer: Debian Nagios Maintainer Group <pkg-nagios-devel@lists.alioth.debian.org>
 Uploaders: Bernd Zeimetz <bzed@debian.org>, Jan Wagner <waja@cyconet.org>
-Build-Depends: debhelper (>= 8.0.0), python, python-debian, quilt (>= 0.46-7), autotools-dev, dh-autoreconf, autotools-dev, flex, libmemcached-dev, libvarnishapi-dev, pkg-config
+Build-Depends: debhelper (>= 8.0.0), python, python-debian, quilt (>= 0.46-7), autotools-dev, dh-autoreconf, flex, libmemcached-dev [!hurd-i386 !arm64], libvarnishapi-dev [!hurd-i386 !m68k], pkg-config
 Standards-Version: 3.9.5
 Vcs-Git: git://anonscm.debian.org/pkg-nagios/pkg-nagios-plugins-contrib
 Vcs-Browser: http://anonscm.debian.org/gitweb/?p=pkg-nagios/pkg-nagios-plugins-contrib;a=summary

--- a/debian/rules
+++ b/debian/rules
@@ -5,6 +5,17 @@
 export DH_VERBOSE=1
 
 PLUGINS := $(shell find $(CURDIR) -mindepth 1 -maxdepth 1 -name .git -prune -o -name .pc -prune -o -name debian -prune -o -type d -printf '%f\n' | sort)
+
+ifeq ($(DEB_HOST_ARCH),$(filter $(DEB_HOST_ARCH), hurd-i386))
+	PLUGINS := $(filter-out check_memcached check_varnish,$(PLUGINS))
+endif
+ifeq ($(DEB_HOST_ARCH),$(filter $(DEB_HOST_ARCH), arm64))
+	PLUGINS := $(filter-out check_memcached,$(PLUGINS))
+endif
+ifeq ($(DEB_HOST_ARCH),$(filter $(DEB_HOST_ARCH), m68k))
+	PLUGINS := $(filter-out check_varnish,$(PLUGINS))
+endif
+
 PKGNAME = nagios-plugins-contrib
 
 %:


### PR DESCRIPTION
theoretically, we should edit the description on hurd too, but I was too lazy for that.

also, check's control file could learn an architecture field, but lazy²
