### PR TITLE
Escape '+' in 'uname -v' output in freebsd_check_running_version()

### DIFF
--- a/dsa/checks/dsa-check-running-kernel
+++ b/dsa/checks/dsa-check-running-kernel
@@ -172,7 +172,7 @@ freebsd_check_running_version() {
 	local imagefile="$1"; shift
 
 	local r="$(uname -r)"
-	local v="$(uname -v| sed -e 's/^#[0-9]*/&:/')"
+	local v="$(uname -v| sed -e 's/^#[0-9]*/&:/' -e 's/\+/\\+/g')"
 
 	local q='@\(#\)FreeBSD '"$r $v"
 


### PR DESCRIPTION
When I tried the `check_running_kernel` check on a fresh install of `Debian GNU/kFreeBSD testing (jessie)`, I got the following result:

```
root@kfreebsd-01:~# /usr/lib/nagios/plugins/check_running_kernel 
WARNING: Currently running kernel (GNU/kFreeBSD 10.0-1-amd64 #0 Tue, 20 May 2014 12:47:21 +0100) does not match on disk image (~ 2014-05-22 19:41:24)
root@kfreebsd-01:~# 
```

After a short investigation, I noticed that the `uname -v` output contains a time zone, which includes a `+` character - this output is later used in a regular expression, so the `+` from the time zone will be interpreted there, and must therefore be escaped. With this change, I get the expected result:

```
root@kfreebsd-01:~# ./check_running_kernel 
OK: Running kernel matches on disk image: [GNU/kFreeBSD 10.0-1-amd64 #0 Tue, 20 May 2014 12:47:21 +0100]
root@kfreebsd-01:~# 
```
