### PR TITLE
fix uom of check_libvirt

### DIFF
--- a/check_libvirt/check_libvirt
+++ b/check_libvirt/check_libvirt
@@ -224,7 +224,7 @@ eval
 			chop($output);
 			chop($output);
 			$output = $up . "/" . $cnt . " VMs up: " . $output;
-			$np->add_perfdata(label => "vmcount", value => $up, uom => 'units', threshold => $np->threshold);
+			$np->add_perfdata(label => "vmcount", value => $up, uom => '', threshold => $np->threshold);
 			$result = $np->check_threshold(check => $up);
 		}
 		elsif (uc($command) eq "POOL")


### PR DESCRIPTION
 * the actual unit of check_libvirt is 'units', which is not a valid UOM
   (https://www.monitoring-plugins.org/doc/guidelines.html#AEN201)
   so tools like icinga2 cannot interprete the performance data
 * remove the UOM to an empty string
   -> no unit specified - assume a number (int or float) of things
      (eg, users, processes, load averages)