### PR TITLE
check_nfsmount: check nfs4 mounts, too

### DIFF
--- a/check_nfsmounts/check_nfsmounts
+++ b/check_nfsmounts/check_nfsmounts
@@ -78,7 +78,7 @@ if(!open MTAB,"< /etc/mtab") {
 my @dirs=();
 my %mountmodes=();
 while(my $line=<MTAB>) {
-  if($line =~ /^[^ ]+ [^ ]+ nfs /) {
+  if($line =~ /^[^ ]+ [^ ]+ nfs[4]? /) {
     my @fields=split(/\s+/,$line);
     my $mountpoint=$fields[1];
     push(@dirs,$mountpoint);


### PR DESCRIPTION
Small change to allow this check to work with nfs4 mounts too.