### PR TITLE
check_v46 remove leading spaces from perf data

### DIFF
--- a/check_v46/check_v46
+++ b/check_v46/check_v46
@@ -163,7 +163,7 @@ foreach my $p (@protocols) {
 
         # Strip off performance data from the $first line of plugin
         # output.
-        $first =~ s/^([^\|]+)\|(.*)/$1/;
+        $first =~ s/^([^\|]+)\|\s*(.*)/$1/;
         $out->{$p}->{$a}->{first} = $first;
 
         # Add lc($p) as prefix to performance data labels, e.g.


### PR DESCRIPTION
Some plugins, like check_ssh, add a leading space to the perf data and check_v46 should remove this space or the prepended ipv4_a1_ and ipv6_a1_ will have a trailing space because service-perfdata scripts will fail to parse the performance data. 

Example output with trailing space:
```
$ /usr/lib/naemon/plugins/check_v46 --debug-wrapper -a 192.168.3.1 -A 2001:470:1f15:a46::1 /usr/lib/naemon/plugins/check_ssh -P 2.0 -p 22987
debug: Running '/usr/lib/naemon/plugins/check_ssh -6 -P 2.0 -p 22987 --hostname 2001:470:1f15:a46::1
debug: Plugin output 1st line: 'SSH OK - OpenSSH_6.6.1p1 Debian-4~bpo70+1 (protocol 2.0) | time=0.088580s;;;0.000000;10.000000'
debug: Reformatted performance data: 'ipv6_a1_ time=0.088580s;;;0.000000;10.000000'
debug: Plugin result: 0 (OK)
debug: Running '/usr/lib/naemon/plugins/check_ssh -4 -P 2.0 -p 22987 --hostname 192.168.3.1
debug: Plugin output 1st line: 'SSH OK - OpenSSH_6.6.1p1 Debian-4~bpo70+1 (protocol 2.0) | time=0.090877s;;;0.000000;10.000000'
debug: Reformatted performance data: 'ipv4_a1_ time=0.090877s;;;0.000000;10.000000'
debug: Plugin result: 0 (OK)
OK: IPv6/2001:470:1f15:a46::1 OK, IPv4/192.168.3.1 OK | ipv6_a1_ time=0.088580s;;;0.000000;10.000000 ipv4_a1_ time=0.090877s;;;0.000000;10.000000
                                                        ^^^^^^^^^^^^^^
Status details:
IPv6/2001:470:1f15:a46::1:
SSH OK - OpenSSH_6.6.1p1 Debian-4~bpo70+1 (protocol 2.0)
IPv4/192.168.3.1:
SSH OK - OpenSSH_6.6.1p1 Debian-4~bpo70+1 (protocol 2.0)
```