### PR TITLE
[check_ajp] Fix "or die" expressions.

### DIFF
--- a/check_ajp/check_ajp
+++ b/check_ajp/check_ajp
@@ -61,8 +61,8 @@ my $expected = pack 'C5'    # Format template.
     , 0x09                  # Type of packet. 9 = CPong reply.
 ;
 
-$iaddr = inet_aton($app) || xdie("No host given !");
-$paddr = sockaddr_in($port, $iaddr) || xdie("Wrong port !");
+$iaddr = inet_aton($app) or xdie("No host given !");
+$paddr = sockaddr_in($port, $iaddr) or xdie("Wrong port !");
 $proto = getprotobyname 'tcp';
 
 $time1 = time();
@@ -70,10 +70,10 @@ $time1 = time();
 eval {
 	local $SIG{ALRM} = sub { die "alarm\n" };
 	alarm($timeout);
-	socket $sock, PF_INET, SOCK_STREAM, $proto || xdie("socket !");
-	connect $sock, $paddr  || xdie("connect !");
-	syswrite $sock, $ping || xdie("syswrite !");
-	sysread $sock, $pong, 5 || xdie("sysread !");
+	socket $sock, PF_INET, SOCK_STREAM, $proto or xdie("socket !");
+	connect $sock, $paddr or xdie("connect !");
+	syswrite $sock, $ping or xdie("syswrite !");
+	sysread $sock, $pong, 5 or xdie("sysread !");
 	alarm(0);
 }; 
 


### PR DESCRIPTION
Using || ends up binding too tightly to the operand on the left, so the `|| xdie` expressions never do anything because all of those trailing-parameters to system calls are not undefined.

Changing them to `or xdie` causes them to actually do what you wanted them to do, which was actually terminate if a system call failed.

I discovered this by using `check_ajp` across an stunnel setup where the remote server wouldn't properly handshake. The "pong" result ends up being the literal string `null` for some reason, but the real problem is that `sysread` is throwing a "Connection reset" error. `check_ajp` wasn't dying when `sysread` was throwing an error, so ... it continued and returned an UNKNOWN response.