### PR TITLE
check-running-kernel: Add support for ZSTD compression

### DIFF
--- a/debian/patches/dsa/check_running_kernel_zstd_fix
+++ b/debian/patches/dsa/check_running_kernel_zstd_fix
@@ -1,0 +1,13 @@
+Index: pkg-nagios-plugins-contrib/dsa/checks/dsa-check-running-kernel
+===================================================================
+--- dsa-check-running-kernel.dist	2022-03-12 21:36:28.000000000 +0100
++++ dsa-check-running-kernel	2022-03-12 21:36:32.000000000 +0100
+@@ -162,6 +162,8 @@
+ 	cat_vmlinux "$image" "\x02\x21\x4c\x18"  "lz4 -dc"  0
+ 	# lzo compressed image
+ 	cat_vmlinux "$image" "\x89\x4c\x5a\x4f\x00\x0d\x0a\x1a"  "lzop -dc"  0
++	# zstd compressed image
++	cat_vmlinux "$image" "\x28\xb5\x2f\xfd"  "zstd -d" 0
+ 
+ 	echo "ERROR: Unable to extract kernel image." 2>&1
+ 	exit 1

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -58,3 +58,4 @@ check_email_delivery/check_smtp_send-hello
 check_raid/sort_megacli_numerical
 check_raid/hpacucli_cache_fail
 check_raid/fix_unparsed_error_cciss
+dsa/check_running_kernel_zstd_fix


### PR DESCRIPTION
Dear Bernd and Jan,

first things first: Thanks a stack for conceiving and maintaining this collection of fine monitoring plugins.

As this is our very first contribution to Debian, please bear with us [^newbie]. We recently discovered the `check_running_kernel` program and are now running it on 40+ machines. This is not _that_ much, but it was enough diversity to give us the opportunity to discover some minor shortcomings, mostly on machines running derivate, non-vanilla Debian distributions like Proxmox and Ubuntu.

- First, we found that a modern Debian bullseye-based PVE/Proxmox machine already used a Linux kernel with ZSTD compression which was not supported yet.
- ~~Secondly, we discovered that on the same Proxmox machine, and on another vanilla Ubuntu 20.04 machine, both running 5.x Linux kernel versions, there was a suffix added to the on-disk kernel image, which we stripped off using `sed` in order to satisfy the comparison operation. You can find more details about this topic in the comment section below.~~ I've diverted this topic to #92 in order to keep things separate.

We hope you like those improvements and ask you to let us know about any adjustments you would like to see.

With kind regards,
Andreas.

/cc @tonkenfo

[^newbie]: While we just also signed up to https://salsa.debian.org/, we discovered this repository also on GitHub and found that both of you might be exchanging patches between here and https://salsa.debian.org/nagios-team/pkg-nagios-plugins-contrib already. So, we are submitting this patch to this repository. If this is wrong, please advise different places where to submit this patch.
